### PR TITLE
Adding Spring Boot CI Template

### DIFF
--- a/.github/workflows/spring-boot.yml
+++ b/.github/workflows/spring-boot.yml
@@ -1,0 +1,34 @@
+name: Spring Boot CI/CD
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'adopt'
+
+      - name: Install dependencies
+        run: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+        working-directory: ./raimed2Back
+
+      - name: Run tests and collect coverage
+        run: mvn -B test
+        working-directory: ./raimed2Back
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./target/site/jacoco/jacoco.xml

--- a/raimed2Back/pom.xml
+++ b/raimed2Back/pom.xml
@@ -157,6 +157,25 @@
 					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.12</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
## Description

Ajout de la CI pour Spring Boot :
- Set up JDK 21
- Cache Maven Packages
- Build and Test with Maven

## Type de changement

- [ ] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Amélioration de la documentation
- [X] CI

## Liste des changements

- Ajout de la CI pour Spring Boot

## Captures d'écran (si applicable)

## Checklist

- [x] Tous les tests unitaires passent
- [ ]  60 % de couverture de code sur la MR
- [x] Le code compile et se lance chez vous en local
- [x] Ticket Jira complété